### PR TITLE
[16.0][FIX] partner_tier_validation Opening Contact form from create and edit many2one

### DIFF
--- a/partner_tier_validation/views/res_partner_view.xml
+++ b/partner_tier_validation/views/res_partner_view.xml
@@ -8,9 +8,17 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
 
-            <!-- Tier Validation UI needs the state field to be in the form -->
+            <!-- Tier Validation UI needs the computed fields to be in the form -->
+            <!-- when opening contact form by clicking create and edit from
+             many2one -->
             <field name="stage_id" position="before">
                 <field name="state" invisible="1" />
+                <field name="need_validation" invisible="1" />
+                <field name="validated" invisible="1" />
+                <field name="rejected" invisible="1" />
+                <field name="can_review" invisible="1" />
+                <field name="next_review" invisible="1" />
+                <field name="review_ids" invisible="1" />
             </field>
 
         </field>


### PR DESCRIPTION
Try to create a contact record from many2one res.partner fields after installing partner_tier_validation module.

Example Go to Sales>Quotation>New>Enter a new customer name and click on Create and Edit

![Screenshot from 2024-01-03 13-23-49](https://github.com/ursais/partner-contact/assets/122819330/2d9108c7-eac7-4d53-bc62-24b07a9746a2)

After adding these computed fields in the res.partner form view no longer facing the error.